### PR TITLE
Fix :box face argument

### DIFF
--- a/doom-alabaster-theme.el
+++ b/doom-alabaster-theme.el
@@ -128,7 +128,7 @@
    (font-lock-preprocessor-face           :foreground operators)
    (font-lock-preprocessor-char-face      :foreground operators)
    ;;;; forge
-   (forge-topic-label                     :box '(:line-width -1 :style none))
+   (forge-topic-label                     :box '(:line-width -1 :style nil))
    ;;;; git-commit
    (git-commit-comment-branch-local       :inherit 'magit-branch-local)
    (git-commit-comment-branch-remote      :inherit 'magit-branch-remote)


### PR DESCRIPTION
At least in some Emacs 30 prerelease, an invalid argument to the `:style` of the box will prevent loading the theme. Using `nil` instead of `'none` then.